### PR TITLE
Improved error handling

### DIFF
--- a/src/ads-client-invoke-rpc-method.js
+++ b/src/ads-client-invoke-rpc-method.js
@@ -6,7 +6,7 @@ module.exports = function (RED) {
     //Properties
     this.name = config.name
     this.methodName = config.methodName
-	
+
     //Getting the ads-client instance
     this.connection = RED.nodes.getNode(config.connection)
 
@@ -15,23 +15,17 @@ module.exports = function (RED) {
 
       if (!this.connection) {
         this.status({ fill: 'red', shape: 'dot', text: `Error: No connection configured` })
-        this.error(`Error: No connection configured`, msg)
-
-        if (done) {
-          done(new Error(`Error: No connection configured`))
-        }
-        return
+        var err = new Error(`No connection configured`);
+        (done)? done(err):  this.error(err, msg);
+        return;
       }
 
       //We need to have string in msg.topic if methodName is empty
       if ( (this.methodName || '') === '' && (!msg.topic || typeof (msg.topic) !== 'string')) {
         this.status({ fill: 'red', shape: 'dot', text: `Error: Input msg.topic not valid string` })
-        this.error(`Error: Input msg.topic is missing or it's not valid string`, msg)
-
-        if (done) {
-          done(new Error(`Error: Input msg.topic is missing or it's not valid string`))
-        }
-        return
+        var err = new Error(`Input msg.topic is missing or it's not valid string`);
+        (done)? done(err):  this.error(err, msg);
+        return;
       }
 
       if (!this.connection.isConnected()) {
@@ -41,20 +35,16 @@ module.exports = function (RED) {
 
         } catch (err) {
           //Failed to connect, we can't work..
-          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` })
-          this.error(`Error: Not connected to the target`, msg)
-
-          if (done) {
-            done(new Error(`Error: Not connected to the target`))
-          }
-          return
+          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` });
+          (done)? done(err):  this.error(err, msg);
+          return;
         }
       }
 
 
       const fullMethodCall = this.methodName === '' ? msg.topic : this.methodName
-	    const [functionBlock, methodToCall] = fullMethodCall.split(/\.(?=[^\.]+$)/); //Split on last dot (.)
-	  
+      const [functionBlock, methodToCall] = fullMethodCall.split(/\.(?=[^\.]+$)/); //Split on last dot (.)
+
       //Finally, calling the RPC method
       try {
         const res = await this.connection.getClient().invokeRpcMethod(
@@ -77,14 +67,12 @@ module.exports = function (RED) {
         }
 
       } catch (err) {
-        const errInfo = this.connection.formatError(err)
 
         this.status({ fill: 'red', shape: 'dot', text: `Error: Last call failed` })
-        this.error(`Error: Calling "${fullMethodCall}" failed: ${errInfo.message}`, errInfo)
+        this.connection.formatError(err,msg);
+        (done)? done(err):  this.error(err, msg);
+        return;
 
-        if (done) {
-          done(errInfo)
-        }
       }
 
     })

--- a/src/ads-client-read-symbol.js
+++ b/src/ads-client-read-symbol.js
@@ -15,23 +15,17 @@ module.exports = function (RED) {
 
       if (!this.connection) {
         this.status({ fill: 'red', shape: 'dot', text: `Error: No connection configured` })
-        this.error(`Error: No connection configured`, msg)
-
-        if (done) {
-          done(new Error(`Error: No connection configured`))
-        }
-        return
+        var err = new Error(`No connection configured`);
+        (done)? done(err):  this.error(err, msg);
+        return;
       }
 
       //We need to have string in msg.topic if variableName is empty
       if (this.variableName === '' && (!msg.topic || typeof (msg.topic) !== 'string')) {
         this.status({ fill: 'red', shape: 'dot', text: `Error: Input msg.topic not valid string` })
-        this.error(`Error: Input msg.topic is missing or it's not valid string`, msg)
-
-        if (done) {
-          done(new Error(`Error: Input msg.topic is missing or it's not valid string`))
-        }
-        return
+        var err = new Error(`Input msg.topic is missing or it's not valid string`);
+        (done)? done(err):  this.error(err, msg);
+        return;
       }
 
       if (!this.connection.isConnected()) {
@@ -41,13 +35,9 @@ module.exports = function (RED) {
           
         } catch (err) {
           //Failed to connect, we can't work..
-          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` })
-          this.error(`Error: Not connected to the target`, msg)
-
-          if (done) {
-            done(new Error(`Error: Not connected to the target`))
-          }
-          return
+          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` });
+          (done)? done(err):  this.error(err, msg);
+          return;
         }
       }
 
@@ -72,14 +62,12 @@ module.exports = function (RED) {
         }
 
       } catch (err) {
-        const errInfo = this.connection.formatError(err)
-        
-        this.status({ fill: 'red', shape: 'dot', text: `Error: Last read failed` })
-        this.error(`Error: Reading variable "${variableToRead}" failed: ${errInfo.message}`, errInfo)
 
-        if (done) {
-          done(errinfo)
-        }
+        this.status({ fill: 'red', shape: 'dot', text: `Error: Last read failed` })
+        this.connection.formatError(err,msg);
+        (done)? done(err):  this.error(err, msg);
+        return;
+
       }
 
     })

--- a/src/ads-client-write-symbol.js
+++ b/src/ads-client-write-symbol.js
@@ -16,23 +16,17 @@ module.exports = function (RED) {
 
       if (!this.connection) {
         this.status({ fill: 'red', shape: 'dot', text: `Error: No connection configured` })
-        this.error(`Error: No connection configured`, msg)
-
-        if (done) {
-          done(new Error(`Error: No connection configured`))
-        }
-        return
+        var err = new Error(`No connection configured`);
+        (done)? done(err):  this.error(err, msg);
+        return;
       }
 
       //We need to have string in msg.topic if variableName is empty
       if (this.variableName === '' && (!msg.topic || typeof (msg.topic) !== 'string')) {
         this.status({ fill: 'red', shape: 'dot', text: `Error: Input msg.topic not valid string` })
-        this.error(`Error: Input msg.topic is missing or it's not valid string`, msg)
-
-        if (done) {
-          done(new Error(`Error: Input msg.topic is missing or it's not valid string`))
-        }
-        return
+        var err = new Error(`Input msg.topic is missing or it's not valid string`);
+        (done)? done(err):  this.error(err, msg);
+        return;
       }
 
       if (!this.connection.isConnected()) {
@@ -42,13 +36,9 @@ module.exports = function (RED) {
 
         } catch (err) {
           //Failed to connect, we can't work..
-          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` })
-          this.error(`Error: Not connected to the target`, msg)
-
-          if (done) {
-            done(new Error(`Error: Not connected to the target`))
-          }
-          return
+          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` });
+          (done)? done(err):  this.error(err, msg);
+          return;
         }
       }
 
@@ -77,14 +67,12 @@ module.exports = function (RED) {
         }
 
       } catch (err) {
-        const errInfo = this.connection.formatError(err)
 
         this.status({ fill: 'red', shape: 'dot', text: `Error: Last write failed` })
-        this.error(`Error: Writing variable "${variableToWrite}" failed: ${errInfo.message}`, errInfo)
+        this.connection.formatError(err,msg);
+        (done)? done(err):  this.error(err, msg);
+        return;
 
-        if (done) {
-          done(errinfo)
-        }
       }
 
     })


### PR DESCRIPTION
 Suggestions for error handling:
 - Only use done(err) / node.error, not both
 - Add adsError info to msg
 - Subscription node: only show first error during connection procedure to prevent log spam (+2 squashed commit)

1) Reading the following topic: [nodered.org](https://discourse.nodered.org/t/best-practice-for-use-of-done-and-error/39063). It seems that done(err) and node.error() shouldn't be called together. As they serve the same purpose but for different node-red versions. 

2) I saw the formatError() function, but couldn't figure out why a new object is created. I modified it in a way it still appends the ads error to the message. And also the possibility to append the adsErrorInfo object to the msg. If the catch node is used, this object will be fully available for debugging. What do you think about this?

3) In the subscription node, only the first error is logged to prevent continually spamming of errors in the log. (Still need to do this for subscription errors?)

4) There are some other cleanups to prevent double errors. Ex. in ads-client-connection.js: connect() only throws an error. The caller needs to catch the error and decide if it wants to log it or not.

These are all suggestions, everything can be debated. 

