### PR TITLE
Version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 30.06.2021
+### Added
+  - New node `Connection Status` that reports ADS connection status changes
+    - Automatically outputs latest connection status when changes detected
+    - Can also be read manually using input trigger
+    - Outputs true/false (ok/not ok) and connection info
+  - New node `Read Runtime State` that implements ads-client library `readPlcRuntimeState()`
+    - Possible to read PLC status (run, stop) from Node-RED
+  - New node `Read System Manager State` that implements ads-client library `readSystemManagerState()`
+    - Possible to read system manager status (run, config) from Node-RED
+  - Updated `ADS connection` node
+    - Automatically tries to connect to the target PLC in the background
+    - Before the connection was retried only when reading/writing/subscribing
+    - Now automatically connects when possible -> supports the new `Connection Status` node
+  - Updated `Subscribe` node
+    - Listens on connection state changes in a better way than before
+    
 
 ## [1.1.1] - 30.05.2021
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "node-red-contrib-ads-client",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "ads-client": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/ads-client/-/ads-client-1.10.4.tgz",
-      "integrity": "sha512-Xaa5ioYBUqgT4uJ7fM6ZVh4//JfxzloPBqKlyTVqAbO4jbblXQ1+eE7zFexSK1nv6hSM4OgFeW1xWWoLnlk2jQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/ads-client/-/ads-client-1.10.7.tgz",
+      "integrity": "sha512-W+2XuH3VPrYSX9gtXi5dcUuMmZ2ZjbAUwajUyJeCptWVpPsvUVg9LmDBFl2EPWM/eBd6wwwZ/oXFcj82UCLUsw==",
       "requires": {
-        "debug": "^4.1.1",
-        "iconv-lite": "^0.5.1",
+        "debug": "^4.3.1",
+        "iconv-lite": "^0.5.2",
         "long": "^4.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "ads-client": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/ads-client/-/ads-client-1.10.7.tgz",
-      "integrity": "sha512-W+2XuH3VPrYSX9gtXi5dcUuMmZ2ZjbAUwajUyJeCptWVpPsvUVg9LmDBFl2EPWM/eBd6wwwZ/oXFcj82UCLUsw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/ads-client/-/ads-client-1.11.0.tgz",
+      "integrity": "sha512-N8JwgRKfk/X3E5FtZtSdsRB3oCZvUEc0Dbz8cKomSXr0eAEqlzkfhP6Wyn8KPn+hj5BwADJ8+Za3TqMKVAWxpw==",
       "requires": {
         "debug": "^4.3.1",
         "iconv-lite": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ads-client",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Beckhoff TwinCAT ADS client library for Node-RED (unofficial). Connects to Beckhoff TwinCAT automation systems using ADS protocol.",
   "keywords": [
     "node-red",
@@ -29,7 +29,7 @@
     "url": "https://github.com/jisotalo/node-red-contrib-ads-client.git"
   },
   "dependencies": {
-    "ads-client": "^1.10.7"
+    "ads-client": "^1.11.0"
   },
   "devDependencies": {},
   "files": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/jisotalo/node-red-contrib-ads-client.git"
   },
   "dependencies": {
-    "ads-client": "^1.10.4"
+    "ads-client": "^1.10.7"
   },
   "devDependencies": {},
   "files": [
@@ -43,7 +43,10 @@
       "ads-client-read-symbol": "src/ads-client-read-symbol.js",
       "ads-client-write-symbol": "src/ads-client-write-symbol.js",
       "ads-client-subscribe": "src/ads-client-subscribe.js",
-	    "ads-client-invoke-rpc-method": "src/ads-client-invoke-rpc-method.js"
+      "ads-client-invoke-rpc-method": "src/ads-client-invoke-rpc-method.js",
+      "ads-client-read-runtime-state": "src/ads-client-read-runtime-state.js",
+      "ads-client-read-system-manager-state": "src/ads-client-read-system-manager-state.js",
+      "ads-client-connection-status": "src/ads-client-connection-status.js"
     }
   }
 }

--- a/src/ads-client-connection-status.html
+++ b/src/ads-client-connection-status.html
@@ -1,0 +1,192 @@
+<script type="text/javascript">
+  RED.nodes.registerType('ads-client-connection-status', {
+    paletteLabel: 'ADS - Connection Status',
+    category: 'TwinCAT ADS',
+    icon: 'font-awesome/fa-info',
+    align: 'right',
+    color: '#3FADB5',
+    outputs: 1,
+    outputLabels: 'Status',
+    defaults: { 
+      name: { value: '' },
+      connection: { value: null, type: "ads-client-connection" },
+    },
+    label: function () {
+      if (this.connection === null)
+        return `${(this.name || `ADS - Connection Status`)} (*Not configured*)`;
+
+        console.log()
+      if (this.name) {
+        return this.name
+      }
+
+      const connectionNode = RED.nodes.node(this.connection)
+
+      if (connectionNode && connectionNode.name)
+        return `ADS - Connection Status (${connectionNode.name})`;
+      else if (connectionNode)
+        return `ADS - Connection Status (${connectionNode.targetAmsNetId}:${connectionNode.targetAdsPort})`;
+      
+      return `ADS - Connection Status`;
+    },
+    oneditprepare: function () {
+    }
+  });
+</script>
+
+
+
+<!-- Properties -->
+<script type="text/html" data-template-name="ads-client-connection-status">
+  <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name (optional)">
+  </div>
+
+  <div class="form-row">
+      <label for="node-input-connection"><i class="fa fa-bookmark"></i> ADS connection</label>
+      <input type="text" id="node-input-connection" placeholder="ADS Connection">
+  </div>
+</script>
+
+
+
+<!-- Help -->
+<script type="text/html" data-help-name="ads-client-connection-status">
+  <p>
+    Subscribes to given variable to receive notifications.
+  </p>
+
+
+<h3>Properties (settings)</h3>
+  <dl class="message-properties">
+    <dt>Name
+      <span class="property-type">string</span>
+    </dt>
+    <dd> Optional node name</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>ADS connection
+      <span class="property-type">ads-client-connection</span>
+    </dt>
+    <dd> ADS client connection (target system) to use</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>Variable name
+      <span class="property-type">string</span>
+    </dt>
+    <dd> Variable name/path to read</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>Subscription mode
+      <span class="property-type"></span>
+    </dt>
+    <dd> How to subscribe to the variable (see details)</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>Cycle time [ms]
+      <span class="property-type">number</span>
+    </dt>
+    <dd> How often the PLC should check if value has changed (or how often to send, see details)</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>Initial delay [ms]
+      <span class="property-type">string</span>
+    </dt>
+    <dd> How long to wait before sending the first notification</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>Retry interval [ms]
+      <span class="property-type">number</span>
+    </dt>
+    <dd> If connecting or subscribing fails, how often to try again until success</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>Control subscription with input
+      <span class="property-type">boolean</span>
+    </dt>
+    <dd> If checked, node subscription is controlled with input (see details)</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>Resubscribe timeout [ms]
+      <span class="property-type">number</span>
+    </dt>
+    <dd> How long to wait for new notifications after connection loss.
+      If no data received in given time, node will try to subscribe again.
+    </dd>
+  </dl>
+
+
+<h3>Inputs</h3>
+  <dl class="message-properties">
+    <dt>topic
+      <span class="property-type">undefined | string</span>
+    </dt>
+    <dd> If given and no variable name set in properties, this topic is used as variable name.</code></dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>subscribe
+      <span class="property-type">undefined | boolean</span>
+    </dt>
+    <dd> If <code>Control subscription with input</code> is checked, this input is used to subscribe/unsubscribe (see details).</code></dd>
+  </dl>
+
+
+<h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload <span class="property-type">any</span></dt>
+    <dd>The value read</dd>
+    <dt>type <span class="property-type">object</span></dt>
+    <dd>Variable data type information</dd>
+    <dt>symbol <span class="property-type">object</span></dt>
+    <dd>Variable symbol information</dd>
+    <dt>timestamp <span class="property-type">object</span></dt>
+    <dd>Variable timestamp</dd>
+    <dt>... <span class="property-type">any</span></dt>
+    <dd>All input <code>msg</code> properties are forwarded</dd>
+  </dl>
+
+<h3>Details</h3>
+  <p>
+    If mode is <code>on-change</code>, the PLC sends a notification only when value has changed. The notification is sent in <code>cycle time</code> intervals at maximum.
+    So if cycle time is 200 ms and the value changes every 10 ms, a new value is still received every 200 ms only.
+  </p>
+  <p>
+    If mode is <code>cyclic</code>, the PLC sends a notification every <code>cycle time</code> interval (even if the value hasn't changed).
+    So if cycle time is 200 ms and the value changes every 10 seconds, a new value is still received every 200 ms.
+  </p>
+  <p>
+    <b>Note:</b> With default settings the node has no input as it's not needed.
+  </p>
+  <p>
+    If the variable name is not set in properties, the input <code>msg.topic</code> is used as variable name instead.
+  </p>
+  <p>
+    If the <code>Control subscription with input</code> is checked, the node doesn't subscribe automatically.
+    It will subscribe only when receiving input <code>msg.subscribe</code> that has truthy value (like <code>true</code>, <code>1</code>..).
+    The node can then be unsubscribed by giving a non-truthy value (like <code>false</code>, <code>0</code>..) to input <code>msg.subscribe</code>.
+  </p>
+  <p>
+    See <code>ads-client</code> readme for help. Valid variable name for TwinCAT 3 can be something like <code>GVL.VariableName</code>
+  </p>
+
+
+<h3>References</h3>
+  <ul>
+    <li><a href="https://github.com/jisotalo/ads-client#subscribing-to-plc-variables-device-notifications" target="_blank" style="text-decoration: underline">
+      ads-client subscribe() readme
+    </a></li>
+    <li><a href="https://jisotalo.github.io/ads-client/Client.html#subscribe" target="_blank" style="text-decoration: underline">
+      ads-client subscribe() documentation
+    </a></li>
+  </ul>
+</script>

--- a/src/ads-client-connection-status.html
+++ b/src/ads-client-connection-status.html
@@ -5,17 +5,19 @@
     icon: 'font-awesome/fa-info',
     align: 'right',
     color: '#3FADB5',
+    inputLabels: 'Trigger',
     outputs: 1,
     outputLabels: 'Status',
     defaults: { 
       name: { value: '' },
       connection: { value: null, type: "ads-client-connection" },
+      showInput: { value: false },
+      inputs: { value: 0 }
     },
     label: function () {
       if (this.connection === null)
         return `${(this.name || `ADS - Connection Status`)} (*Not configured*)`;
 
-        console.log()
       if (this.name) {
         return this.name
       }
@@ -30,6 +32,18 @@
       return `ADS - Connection Status`;
     },
     oneditprepare: function () {
+      //Stuff that is done when properties panel is opened
+      let node = this
+
+      let checkIfInput = function () {
+        node.inputs = $('#node-input-showInput').is(':checked') ? 1 : 0
+      }
+
+      //If checkbox is checked -> we need input
+      $('#node-input-showInput').change(function () {
+        checkIfInput()
+      })
+
     }
   });
 </script>
@@ -47,6 +61,12 @@
       <label for="node-input-connection"><i class="fa fa-bookmark"></i> ADS connection</label>
       <input type="text" id="node-input-connection" placeholder="ADS Connection">
   </div>
+
+  <div class="form-row">
+    <input type="checkbox" id="node-input-showInput" style="display: inline-block; width: auto; vertical-align: top">
+    <label for="node-input-showInput" style="width: 70%"><span>Show input for manual triggering</span></label>
+  </div>
+
 </script>
 
 
@@ -54,7 +74,7 @@
 <!-- Help -->
 <script type="text/html" data-help-name="ads-client-connection-status">
   <p>
-    Subscribes to given variable to receive notifications.
+    Reports status changes of the selected ADS connection.
   </p>
 
 
@@ -74,119 +94,51 @@
   </dl>
 
   <dl class="message-properties">
-    <dt>Variable name
-      <span class="property-type">string</span>
-    </dt>
-    <dd> Variable name/path to read</dd>
-  </dl>
-
-  <dl class="message-properties">
-    <dt>Subscription mode
-      <span class="property-type"></span>
-    </dt>
-    <dd> How to subscribe to the variable (see details)</dd>
-  </dl>
-
-  <dl class="message-properties">
-    <dt>Cycle time [ms]
-      <span class="property-type">number</span>
-    </dt>
-    <dd> How often the PLC should check if value has changed (or how often to send, see details)</dd>
-  </dl>
-
-  <dl class="message-properties">
-    <dt>Initial delay [ms]
-      <span class="property-type">string</span>
-    </dt>
-    <dd> How long to wait before sending the first notification</dd>
-  </dl>
-
-  <dl class="message-properties">
-    <dt>Retry interval [ms]
-      <span class="property-type">number</span>
-    </dt>
-    <dd> If connecting or subscribing fails, how often to try again until success</dd>
-  </dl>
-
-  <dl class="message-properties">
-    <dt>Control subscription with input
+    <dt>Show input for manual triggering
       <span class="property-type">boolean</span>
     </dt>
-    <dd> If checked, node subscription is controlled with input (see details)</dd>
+    <dd> If checked, the status can be also read using input trigger</dd>
   </dl>
 
-  <dl class="message-properties">
-    <dt>Resubscribe timeout [ms]
-      <span class="property-type">number</span>
-    </dt>
-    <dd> How long to wait for new notifications after connection loss.
-      If no data received in given time, node will try to subscribe again.
-    </dd>
-  </dl>
-
-
-<h3>Inputs</h3>
-  <dl class="message-properties">
-    <dt>topic
-      <span class="property-type">undefined | string</span>
-    </dt>
-    <dd> If given and no variable name set in properties, this topic is used as variable name.</code></dd>
-  </dl>
-
-  <dl class="message-properties">
-    <dt>subscribe
-      <span class="property-type">undefined | boolean</span>
-    </dt>
-    <dd> If <code>Control subscription with input</code> is checked, this input is used to subscribe/unsubscribe (see details).</code></dd>
-  </dl>
 
 
 <h3>Outputs</h3>
   <dl class="message-properties">
-    <dt>payload <span class="property-type">any</span></dt>
-    <dd>The value read</dd>
-    <dt>type <span class="property-type">object</span></dt>
-    <dd>Variable data type information</dd>
-    <dt>symbol <span class="property-type">object</span></dt>
-    <dd>Variable symbol information</dd>
-    <dt>timestamp <span class="property-type">object</span></dt>
-    <dd>Variable timestamp</dd>
+    <dt>payload <span class="property-type">boolean</span></dt>
+    <dd>ADS connection status as boolean (true = connection is OK) </dd>
+    <dt>connection <span class="property-type">object</span></dt>
+    <dd>Connection information (ads-client object)</dd>
     <dt>... <span class="property-type">any</span></dt>
-    <dd>All input <code>msg</code> properties are forwarded</dd>
+    <dd>All input <code>msg</code> properties are forwarded (if using input)</dd>
   </dl>
 
 <h3>Details</h3>
   <p>
-    If mode is <code>on-change</code>, the PLC sends a notification only when value has changed. The notification is sent in <code>cycle time</code> intervals at maximum.
-    So if cycle time is 200 ms and the value changes every 10 ms, a new value is still received every 200 ms only.
+    Status changes are automatically reported when detected.
   </p>
   <p>
-    If mode is <code>cyclic</code>, the PLC sends a notification every <code>cycle time</code> interval (even if the value hasn't changed).
-    So if cycle time is 200 ms and the value changes every 10 seconds, a new value is still received every 200 ms.
+    If <code>Show input for manual triggering</code> is checked, the status can also be read manually.
   </p>
   <p>
-    <b>Note:</b> With default settings the node has no input as it's not needed.
+    <b>Note:</b> Status changes are always reported when detected (even if <code>Show input for manual triggering</code> is checked).
   </p>
   <p>
-    If the variable name is not set in properties, the input <code>msg.topic</code> is used as variable name instead.
+    The output <code>connection</code> has ads-client connection information, similar to:
+    <pre>
+connection {
+  connected: true,
+  isLocal: true,
+  localAmsNetId: '192.168.5.131.1.1',
+  localAdsPort: 38971,
+  targetAmsNetId: '127.0.0.1.1.1',
+  targetAdsPort: '851'
+}</pre>
   </p>
-  <p>
-    If the <code>Control subscription with input</code> is checked, the node doesn't subscribe automatically.
-    It will subscribe only when receiving input <code>msg.subscribe</code> that has truthy value (like <code>true</code>, <code>1</code>..).
-    The node can then be unsubscribed by giving a non-truthy value (like <code>false</code>, <code>0</code>..) to input <code>msg.subscribe</code>.
-  </p>
-  <p>
-    See <code>ads-client</code> readme for help. Valid variable name for TwinCAT 3 can be something like <code>GVL.VariableName</code>
-  </p>
-
 
 <h3>References</h3>
   <ul>
-    <li><a href="https://github.com/jisotalo/ads-client#subscribing-to-plc-variables-device-notifications" target="_blank" style="text-decoration: underline">
-      ads-client subscribe() readme
-    </a></li>
-    <li><a href="https://jisotalo.github.io/ads-client/Client.html#subscribe" target="_blank" style="text-decoration: underline">
-      ads-client subscribe() documentation
+    <li><a href="https://github.com/jisotalo/ads-client" target="_blank" style="text-decoration: underline">
+      ads-client readme
     </a></li>
   </ul>
 </script>

--- a/src/ads-client-connection-status.js
+++ b/src/ads-client-connection-status.js
@@ -1,0 +1,56 @@
+module.exports = function (RED) {
+
+  function AdsClientConnectionStatus(config) {
+    RED.nodes.createNode(this, config)
+
+    //Properties
+    this.name = config.name
+
+    //State
+    this.initialized = false
+    this.connected = false
+
+    //Getting the ads-client instance
+    this.connection = RED.nodes.getNode(config.connection)
+
+    //Event listeners
+    const onConnect = () => onClientStateChange('connect')
+    const onDisconnect = () => onClientStateChange('disconnect')
+    const onReconnect = () => onClientStateChange('reconnect')
+
+
+
+
+    /**
+     * Called when connected/disconnected
+     * @param {*} state 
+     */
+    const onConnectedChange = (newConnectedState) => {
+      
+      //Only send message once
+      if (newConnectedState && (!this.connected)) {
+        this.connected = true
+        this.status({ fill: 'green', shape: 'dot', text: `Connected` })
+
+      } else if (!newConnectedState && (this.connected || !this.initialized)) {
+        this.connected = false
+        this.status({ fill: 'red', shape: 'dot', text: `Not connected` })
+
+      } else {
+        return
+      }
+
+      this.initialized = true
+
+      //Out we go
+      this.send({
+        payload: this.connected,
+        connection: this.connection.getClient() ? this.connection.getClient().connection : null
+      })
+    }
+
+    this.connection.eventEmitter.on('connected', connected => onConnectedChange(connected))
+  }
+
+  RED.nodes.registerType('ads-client-connection-status', AdsClientConnectionStatus)
+}

--- a/src/ads-client-read-runtime-state.html
+++ b/src/ads-client-read-runtime-state.html
@@ -1,0 +1,130 @@
+<script type="text/javascript">
+  RED.nodes.registerType('ads-client-read-runtime-state', {
+    paletteLabel: 'ADS - Read Runtime State',
+    category: 'TwinCAT ADS',
+    icon: 'font-awesome/fa-refresh',
+    color: '#3FADB5',
+    inputs: 1,
+    inputLabels: function() {
+      return this.adsPort === '' ? "Topic as ADS port" : "Read trigger"
+    },
+    outputs: 1,
+    outputLabels: 'Data',
+    defaults: { 
+      name: { value: '' },
+      connection: { value: null, type: "ads-client-connection" },
+      adsPort: { value: 851, required: false, validate: (v) => (v === '' || !isNaN(parseInt(v))) }
+    },
+    label: function () {
+      if(this.connection === null)
+        return  `${(this.name || `ADS - Read Runtime State`)} (*Not configured*)`;
+ 
+      if (this.name) {
+        return this.name
+      }
+
+      return `ADS - Read Runtime State (${(this.adsPort === '' ? `msg.topic` : `${this.adsPort}`)})`;
+    },
+    oneditprepare: function () {
+      //Stuff that is done when properties panel is opened
+    }
+  })
+</script>
+
+
+
+<!-- Properties -->
+<script type="text/html" data-template-name="ads-client-read-runtime-state">
+  <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name (optional)">
+  </div>
+
+  <div class="form-row">
+      <label for="node-input-connection"><i class="fa fa-bookmark"></i> ADS connection</label>
+      <input type="text" id="node-input-connection" placeholder="ADS Connection">
+  </div>
+
+  <div class="form-row">
+      <label for="node-input-adsPort"><i class="fa fa-tag"></i> ADS port (runtime)</label>
+      <input type="text" id="node-input-adsPort" placeholder="ADS port (runtime)">
+  </div>
+  <div class="form-tips"><b>Tip:</b> Leave ADS port empty to use <code>msg.topic</code> input instead.</div>
+
+  <div class="form-row">
+    <!-- Some margin after tip -->
+  </div>
+</script>
+
+
+
+<!-- Help -->
+<script type="text/html" data-help-name="ads-client-read-runtime-state">
+<p>
+  Reads TwinCAT PLC runtime state from given ADS port.
+</p>
+
+
+<h3>Properties (settings)</h3>
+  <dl class="message-properties">
+    <dt>Name
+      <span class="property-type">string</span>
+    </dt>
+    <dd> Optional node name</dd>
+  </dl>
+  
+  <dl class="message-properties">
+    <dt>ADS connection
+      <span class="property-type">ads-client-connection</span>
+    </dt>
+    <dd> ADS client connection (target system) to use</dd>
+  </dl>
+
+  <dl class="message-properties">
+    <dt>ADS port (runtime)
+      <span class="property-type">number | string</span>
+    </dt>
+    <dd> ADS port of the target runtime (TC2: 801, 801.., TC3: 851, 852..)</dd>
+  </dl>
+
+
+<h3>Inputs</h3>
+  <dl class="message-properties">
+    <dt>topic
+      <span class="property-type">undefined | number | string</span>
+    </dt>
+    <dd> If given and no ADS port set in properties, this topic is used as ADS port.</code></dd>
+  </dl>
+
+<h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload <span class="property-type">string</span></dt>
+    <dd>The PLC runtime state as string (Run, Stop.. - See <a href="https://github.com/jisotalo/ads-client/blob/f1a5a07bd0c847b8a92a512c8b99b78eb7838b88/src/ads-client-ads.js#L469" target="_blank">ADS_STATE</a>)</dd>
+    <dt>result <span class="property-type">object</span></dt>
+    <dd>The PLC runtime state object</dd>
+    <dt>... <span class="property-type">any</span></dt>
+    <dd>All input <code>msg</code> properties are forwarded</dd>
+  </dl>
+
+<h3>Details</h3>
+  <p>
+  If the ADS port is not set in properties, the input <code>msg.topic</code> is used as ADS port instead.
+  </p>
+  <p>
+  See <code>ads-client</code> readme for help.
+  </p>
+
+
+<h3>References</h3>
+  <ul>
+    <li><a href="https://github.com/jisotalo/ads-client#starting-and-stopping-the-plc" target="_blank" style="text-decoration: underline">
+      ads-client readme
+    </a></li>
+    <li><a href="https://jisotalo.github.io/ads-client/Client.html#readPlcRuntimeState" target="_blank" style="text-decoration: underline">
+      ads-client readPlcRuntimeState() documentation
+    </a></li>
+    <li><a href="https://github.com/jisotalo/ads-client/blob/f1a5a07bd0c847b8a92a512c8b99b78eb7838b88/src/ads-client-ads.js#L469" target="_blank" style="text-decoration: underline">
+      Possible states (ADS_STATE)
+    </a></li>
+  </ul>
+</script>

--- a/src/ads-client-read-runtime-state.js
+++ b/src/ads-client-read-runtime-state.js
@@ -1,0 +1,76 @@
+module.exports = function (RED) {
+
+  function AdsClientReadRuntimeState(config) {
+    RED.nodes.createNode(this, config)
+
+    //Properties
+    this.name = config.name
+    this.adsPort = config.adsPort
+
+    //Getting the ads-client instance
+    this.connection = RED.nodes.getNode(config.connection)
+
+    //When input is toggled, try to read data
+    this.on('input', async (msg, send, done) => {
+
+      if (!this.connection) {
+        this.status({ fill: 'red', shape: 'dot', text: `Error: No connection configured` })
+        var err = new Error(`No connection configured`);
+        (done)? done(err):  this.error(err, msg);
+        return;
+      }
+
+      //We need to have a valid number in msg.topic if adsPort is empty
+      if (this.adsPort === '' && (!msg.topic || isNaN(parseInt(msg.topic)))) {
+        this.status({ fill: 'red', shape: 'dot', text: `Error: Input msg.topic not a valid number` })
+        var err = new Error(`Input msg.topic is missing or it's not a valid number`);
+        (done)? done(err):  this.error(err, msg);
+        return;
+      }
+
+      if (!this.connection.isConnected()) {
+        //Try to connect
+        try {
+          await this.connection.connect()
+          
+        } catch (err) {
+          //Failed to connect, we can't work..
+          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` });
+          (done)? done(err):  this.error(err, msg);
+          return;
+        }
+      }
+
+      const targetAdsPort = this.adsPort === '' ? parseInt(msg.topic) : this.adsPort
+
+      //Finally, reading the state
+      try {
+        const res = await this.connection.getClient().readPlcRuntimeState(targetAdsPort)
+
+        //We are here -> success
+        this.status({ fill: 'green', shape: 'dot', text: 'Last read successful' })
+
+        send({
+          ...msg,
+          payload: res.adsStateStr,
+          result: res
+        })
+
+        if (done) {
+          done()
+        }
+
+      } catch (err) {
+
+        this.status({ fill: 'red', shape: 'dot', text: `Error: Last read failed` })
+        this.connection.formatError(err,msg);
+        (done)? done(err):  this.error(err, msg);
+        return;
+
+      }
+
+    })
+  }
+
+  RED.nodes.registerType('ads-client-read-runtime-state', AdsClientReadRuntimeState)
+}

--- a/src/ads-client-read-system-manager-state.html
+++ b/src/ads-client-read-system-manager-state.html
@@ -1,0 +1,114 @@
+<script type="text/javascript">
+  RED.nodes.registerType('ads-client-read-system-manager-state', {
+    paletteLabel: 'ADS - Read System Manager State',
+    category: 'TwinCAT ADS',
+    icon: 'font-awesome/fa-refresh',
+    color: '#3FADB5',
+    inputs: 1,
+    inputLabels: function() {
+      return "Read trigger"
+    },
+    outputs: 1,
+    outputLabels: 'Data',
+    defaults: { 
+      name: { value: '' },
+      connection: { value: null, type: "ads-client-connection" }
+    },
+    label: function () {
+      if(this.connection === null)
+        return  `${(this.name || `ADS - Read System Manager State`)} (*Not configured*)`;
+ 
+      if (this.name) {
+        return this.name
+      }
+
+      return `ADS - Read System Manager State`;
+    },
+    oneditprepare: function () {
+      //Stuff that is done when properties panel is opened
+    }
+  })
+</script>
+
+
+
+<!-- Properties -->
+<script type="text/html" data-template-name="ads-client-read-system-manager-state">
+  <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name (optional)">
+  </div>
+
+  <div class="form-row">
+      <label for="node-input-connection"><i class="fa fa-bookmark"></i> ADS connection</label>
+      <input type="text" id="node-input-connection" placeholder="ADS Connection">
+  </div>
+
+  <div class="form-row">
+    <!-- Some margin after tip -->
+  </div>
+</script>
+
+
+
+<!-- Help -->
+<script type="text/html" data-help-name="ads-client-read-system-manager-state">
+<p>
+  Reads TwinCAT System Manager state from target (using ADS port 10000).
+</p>
+<p>
+  <b>NOTE:</b> Used <code>ads-connection</code> needs to have <code>allowHalfOpen</code> setting checked in order to connect to systems running in Config mode.
+</p>
+
+
+<h3>Properties (settings)</h3>
+  <dl class="message-properties">
+    <dt>Name
+      <span class="property-type">string</span>
+    </dt>
+    <dd> Optional node name</dd>
+  </dl>
+  
+  <dl class="message-properties">
+    <dt>ADS connection
+      <span class="property-type">ads-client-connection</span>
+    </dt>
+    <dd> ADS client connection (target system) to use</dd>
+  </dl>
+
+
+<h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload <span class="property-type">string</span></dt>
+    <dd>The system manager state as string (Run, Config.. - See <a href="https://github.com/jisotalo/ads-client/blob/f1a5a07bd0c847b8a92a512c8b99b78eb7838b88/src/ads-client-ads.js#L469" target="_blank">ADS_STATE</a>)</dd>
+    <dt>result <span class="property-type">object</span></dt>
+    <dd>The system manager state object</dd>
+    <dt>... <span class="property-type">any</span></dt>
+    <dd>All input <code>msg</code> properties are forwarded</dd>
+  </dl>
+
+<h3>Details</h3>
+  <p>
+    Reads the target system manager state (Run, Config).
+  </p>
+  <p>
+   <b>NOTE:</b> Used <code>ads-connection</code> needs to have <code>allowHalfOpen</code> setting checked in order to connect to systems running in Config mode.
+  </p>
+  <p>
+    See <code>ads-client</code> readme for help.
+  </p>
+
+
+<h3>References</h3>
+  <ul>
+    <li><a href="https://github.com/jisotalo/ads-client#starting-and-stopping-the-twincat-system" target="_blank" style="text-decoration: underline">
+      ads-client readme
+    </a></li>
+    <li><a href="https://jisotalo.github.io/ads-client/Client.html#readSystemManagerState" target="_blank" style="text-decoration: underline">
+      ads-client readSystemManagerState() documentation
+    </a></li>
+    <li><a href="https://github.com/jisotalo/ads-client/blob/f1a5a07bd0c847b8a92a512c8b99b78eb7838b88/src/ads-client-ads.js#L469" target="_blank" style="text-decoration: underline">
+      Possible states (ADS_STATE)
+    </a></li>
+  </ul>
+</script>

--- a/src/ads-client-read-system-manager-state.js
+++ b/src/ads-client-read-system-manager-state.js
@@ -1,0 +1,65 @@
+module.exports = function (RED) {
+
+  function AdsClientReadSystemManagerState(config) {
+    RED.nodes.createNode(this, config)
+
+    //Properties
+    this.name = config.name
+
+    //Getting the ads-client instance
+    this.connection = RED.nodes.getNode(config.connection)
+
+    //When input is toggled, try to read data
+    this.on('input', async (msg, send, done) => {
+
+      if (!this.connection) {
+        this.status({ fill: 'red', shape: 'dot', text: `Error: No connection configured` })
+        var err = new Error(`No connection configured`);
+        (done)? done(err):  this.error(err, msg);
+        return;
+      }
+
+      if (!this.connection.isConnected()) {
+        //Try to connect
+        try {
+          await this.connection.connect()
+          
+        } catch (err) {
+          //Failed to connect, we can't work..
+          this.status({ fill: 'red', shape: 'dot', text: `Error: Not connected` });
+          (done)? done(err):  this.error(err, msg);
+          return;
+        }
+      }
+
+      //Finally, reading the state
+      try {
+        const res = await this.connection.getClient().readSystemManagerState()
+
+        //We are here -> success
+        this.status({ fill: 'green', shape: 'dot', text: 'Last read successful' })
+
+        send({
+          ...msg,
+          payload: res.adsStateStr,
+          result: res
+        })
+
+        if (done) {
+          done()
+        }
+
+      } catch (err) {
+
+        this.status({ fill: 'red', shape: 'dot', text: `Error: Last read failed` })
+        this.connection.formatError(err,msg);
+        (done)? done(err):  this.error(err, msg);
+        return;
+
+      }
+
+    })
+  }
+
+  RED.nodes.registerType('ads-client-read-system-manager-state', AdsClientReadSystemManagerState)
+}


### PR DESCRIPTION

## [1.2.0] - 30.06.2021
### Added
  - New node `Connection Status` that reports ADS connection status changes
    - Automatically outputs latest connection status when changes detected
    - Can also be read manually using input trigger
    - Outputs true/false (ok/not ok) and connection info
  - New node `Read Runtime State` that implements ads-client library `readPlcRuntimeState()`
    - Possible to read PLC status (run, stop) from Node-RED
  - New node `Read System Manager State` that implements ads-client library `readSystemManagerState()`
    - Possible to read system manager status (run, config) from Node-RED
  - Updated `ADS connection` node
    - Automatically tries to connect to the target PLC in the background
    - Before the connection was retried only when reading/writing/subscribing
    - Now automatically connects when possible -> supports the new `Connection Status` node
  - Updated `Subscribe` node
    - Listens on connection state changes in a better way than before