### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 07.07.2021
+### Added
+  - New setting for `ads-client-connection`: `Debugging level`
+    - Possible to set `ads-client` debugging level from Node-RED
+    - Easier to debug connection problems & library bugs
+### Changed
+  - Thank you [Hopperpop](https://github.com/Hopperpop) for contribution, awesome work!
+    - Better support for nodes that operate at the same time
+      - No more errors when all nodes try to connect to the PLC (`Already connecting to the target`)
+      - Other nodes will wait for the result of the connection that the first node is creating
+    - If first connection to the PLC fails at startup, warning is shown instead of error
+  - Old `ads-client-connection` is always disconnected (if possible) in handled manner when (re)connecting
+
 ## [1.2.0] - 30.06.2021
 ### Added
   - New node `Connection Status` that reports ADS connection status changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ads-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Beckhoff TwinCAT ADS client library for Node-RED (unofficial). Connects to Beckhoff TwinCAT automation systems using ADS protocol.",
   "keywords": [
     "node-red",

--- a/src/ads-client-connection.html
+++ b/src/ads-client-connection.html
@@ -28,7 +28,8 @@
       checkStateInterval: { value: null },
       connectionDownDelay: { value: null },
       allowHalfOpen: { value: false },
-      disableBigInt: { value: false }
+      disableBigInt: { value: false },
+      debuggingLevel: { value: 0 }
     },
     label: function () {
       if (this.name) {
@@ -96,6 +97,11 @@
     </div>
 
     <div id="ads-client-connection-options-tab" style="display:none">
+      <div class="form-row">
+        <label for="node-config-input-debuggingLevel">Debugging level</label>
+        <input type="text" id="node-config-input-debuggingLevel" placeholder="0"> 
+      </div>
+      
       <div class="form-row">
         <input type="checkbox" id="node-config-input-objectifyEnumerations" style="display: inline-block; width: auto; vertical-align: top">
         <label for="node-config-input-objectifyEnumerations" style="width: 70%"><span>objectifyEnumerations</span></label>
@@ -223,6 +229,11 @@
       <li>
         See <a href="https://jisotalo.github.io/ads-client/global.html#Settings" target="_blank" style="text-decoration: underline">
           ads-client settings documentation
+        </a>
+      </li>
+      <li>
+        <b>Debugging level</b> - ads-client debugging level. See <a href="https://github.com/jisotalo/ads-client#debugging" target="_blank" style="text-decoration: underline">
+          ads-client readme
         </a>
       </li>
     </ul>


### PR DESCRIPTION

## [1.3.0] - 07.07.2021
### Added
  - New setting for `ads-client-connection`: `Debugging level`
    - Possible to set `ads-client` debugging level from Node-RED
    - Easier to debug connection problems & library bugs
### Changed
  - Thank you [Hopperpop](https://github.com/Hopperpop) for contribution, awesome work!
    - Better support for nodes that operate at the same time
      - No more errors when all nodes try to connect to the PLC (`Already connecting to the target`)
      - Other nodes will wait for the result of the connection that the first node is creating
    - If first connection to the PLC fails at startup, warning is shown instead of error
  - Old `ads-client-connection` is always disconnected (if possible) in handled manner when (re)connecting