### PR TITLE
Suppress error when connection node is disabled

### DIFF
--- a/src/ads-client-connection-status.js
+++ b/src/ads-client-connection-status.js
@@ -60,7 +60,9 @@ module.exports = function (RED) {
     })
 
     //Listening for connected state change events
-    this.connection.eventEmitter.on('connected', connected => onConnectedChange(connected))
+    if (this.connection){ //Check if node is enabled
+      this.connection.eventEmitter.on('connected', connected => onConnectedChange(connected))
+    }
   }
 
   RED.nodes.registerType('ads-client-connection-status', AdsClientConnectionStatus)


### PR DESCRIPTION
Small fix to suppress an error in the connection-status node when the connection node itself is disabled and not available.

`[error] [ads-client-connection-status:7058d752.b73148] TypeError: Cannot read property 'eventEmitter' of null`